### PR TITLE
Add undo/reset controls and improve layout

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -7,6 +7,7 @@
 .scoreboard {
   width: 100%;
   margin-bottom: 1rem;
+  text-align: left;
 }
 .scoreboard th,
 .scoreboard td {
@@ -15,7 +16,8 @@
 }
 .round-form select {
   margin: 0.5rem;
-  padding: 0.4rem;
+  padding: 0.6rem;
+  font-size: 1.2rem;
 }
 .round-form button {
   margin-top: 0.5rem;
@@ -28,4 +30,5 @@
 .settlement-modal {
   border: none;
   padding: 1rem;
+  text-align: left;
 }

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -85,6 +85,23 @@ function App() {
     setGame(newGame)
   }
 
+  const resetCurrent = () => {
+    const players = game.players.map(p => ({ ...p, score: 0 }))
+    setGame({ players, rounds: [], isFinished: false })
+  }
+
+  const undoLastRound = () => {
+    if (game.rounds.length === 0) return
+    const rounds = game.rounds.slice(0, -1)
+    const players = game.players.map(p => ({ ...p, score: 0 }))
+    rounds.forEach(r => {
+      players.find(p => p.name === r.first).score += 3
+      players.find(p => p.name === r.second).score += 1
+    })
+    const max = Math.max(...players.map(p => p.score))
+    setGame({ players, rounds, isFinished: max > 12 })
+  }
+
   if (showHistory) {
     return <History onBack={()=>setShowHistory(false)} />
   }
@@ -106,6 +123,8 @@ function App() {
       </table>
       <RoundForm players={game.players} onRecord={recordRound} disabled={game.isFinished} />
       <div className="actions">
+        <button onClick={undoLastRound} disabled={game.rounds.length===0}>撤销上局</button>
+        <button onClick={resetCurrent}>重置本局</button>
         <button onClick={()=>setShowSetup(true)}>设置玩家</button>
         <button onClick={()=>setShowHistory(true)}>查看历史</button>
       </div>


### PR DESCRIPTION
## Summary
- enlarge select elements for easier mobile use
- left-align scoreboard and dialogs
- add undo and reset buttons to manage current game

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bfa65d44483318d0d14db09c97edb