### PR TITLE
Store game data in GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,21 @@ included in `/server` for keeping a central history of games.
 
 ### 1. Start the center server
 
-All synced games are written to `server/games.json`. Run the server on your Mac
-or any machine on the same network:
+By default the server reads and writes `games.json` locally inside the `server`
+folder:
 
 ```bash
 cd server
 npm install
 npm start        # use PORT=4000 npm start to change the port
+```
+
+To store the file in a private GitHub repository instead, start the server with
+`GITHUB_TOKEN` and `GITHUB_REPO` (and optionally `GITHUB_BRANCH` and
+`GITHUB_FILE_PATH`):
+
+```bash
+GITHUB_TOKEN=<token> GITHUB_REPO=<owner/repo> npm start
 ```
 
 The server exposes a few JSON endpoints under `/games`:
@@ -59,5 +67,7 @@ entire day's records from `games.json`.
 
 ## use Render host the service
 
-BackEnd API: 'https://guandan-score-api.onrender.com';  
+BackEnd API: 'https://guandan-score-api.onrender.com';
 Static Server: https://guandan-score-ui.onrender.com;
+The Render service is configured with the same GitHub environment variables so
+updates are pushed directly to the private repository.

--- a/server/index.js
+++ b/server/index.js
@@ -1,50 +1,142 @@
 import express from 'express';
 import cors from 'cors';
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataFile = path.join(__dirname, 'games.json');
+
 const app = express();
 const PORT = process.env.PORT || 3030;
 
 app.use(cors());
 app.use(express.json());
 
-const dataFile = path.join(__dirname, 'games.json');
-if (!fs.existsSync(dataFile)) {
-  fs.writeFileSync(dataFile, '[]', 'utf-8');
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_REPO = process.env.GITHUB_REPO; // "owner/repo"
+const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'main';
+const GITHUB_FILE_PATH = process.env.GITHUB_FILE_PATH || 'games.json';
+
+const useGitHub = Boolean(GITHUB_TOKEN && GITHUB_REPO);
+
+let games = [];
+let fileSha = null;
+
+async function loadGames() {
+  if (!useGitHub) {
+    try {
+      const text = await fs.readFile(dataFile, 'utf-8');
+      games = JSON.parse(text);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        games = [];
+        await fs.writeFile(dataFile, '[]', 'utf-8');
+      } else {
+        throw err;
+      }
+    }
+    return;
+  }
+
+  const url = `https://api.github.com/repos/${GITHUB_REPO}/contents/${GITHUB_FILE_PATH}?ref=${GITHUB_BRANCH}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+  });
+  if (res.status === 404) {
+    games = [];
+    fileSha = null;
+    return;
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to fetch file: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  fileSha = data.sha;
+  games = JSON.parse(Buffer.from(data.content, 'base64').toString('utf-8'));
 }
 
-let games = JSON.parse(fs.readFileSync(dataFile, 'utf-8'));
+async function saveGames() {
+  if (!useGitHub) {
+    await fs.writeFile(dataFile, JSON.stringify(games, null, 2));
+    return;
+  }
+
+  const url = `https://api.github.com/repos/${GITHUB_REPO}/contents/${GITHUB_FILE_PATH}`;
+  const body = {
+    message: 'Update games',
+    content: Buffer.from(JSON.stringify(games, null, 2)).toString('base64'),
+    branch: GITHUB_BRANCH,
+  };
+  if (fileSha) body.sha = fileSha;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github.v3+json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to save file: ${res.status} ${text}`);
+  }
+  const data = await res.json();
+  fileSha = data.content.sha;
+}
 
 app.get('/games', (req, res) => {
   res.json(games);
 });
 
-app.post('/games', (req, res) => {
+app.post('/games', async (req, res) => {
   const game = req.body;
   games.unshift(game);
-  fs.writeFileSync(dataFile, JSON.stringify(games, null, 2));
-  res.json({ success: true });
+  try {
+    await saveGames();
+    res.json({ success: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ success: false });
+  }
 });
 
-app.delete('/games/:timestamp', (req, res) => {
+app.delete('/games/:timestamp', async (req, res) => {
   const ts = Number(req.params.timestamp);
   games = games.filter((g) => g.timestamp !== ts);
-  fs.writeFileSync(dataFile, JSON.stringify(games, null, 2));
-  res.json({ success: true });
+  try {
+    await saveGames();
+    res.json({ success: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ success: false });
+  }
 });
 
-app.delete('/games/date/:date', (req, res) => {
+app.delete('/games/date/:date', async (req, res) => {
   const d = req.params.date;
   games = games.filter(
     (g) => new Date(g.timestamp).toISOString().slice(0, 10) !== d
   );
-  fs.writeFileSync(dataFile, JSON.stringify(games, null, 2));
-  res.json({ success: true });
+  try {
+    await saveGames();
+    res.json({ success: true });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ success: false });
+  }
 });
 
-app.listen(PORT, () => {
-  console.log(`Central server listening on port ${PORT}`);
-});
+loadGames()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Central server listening on port ${PORT}`);
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to start server:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- persist `games.json` to a GitHub repository
- document GitHub environment variables required to start the server
- note that Render is configured with these variables
- load and save `games.json` using GitHub's REST API
- handle GitHub failures and boot server after loading data
- allow local development without GitHub variables

## Testing
- `npm install` within `server`
- `PORT=3031 npm start`

------
https://chatgpt.com/codex/tasks/task_e_687f85dfd99c83319d8e6743562eac8e