### PR TITLE
Highlight record days in calendar

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
+        "react-datepicker": "^8.4.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
@@ -2191,6 +2192,59 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.13.tgz",
+      "integrity": "sha512-Qmj6t9TjgWAvbygNEu1hj4dbHI9CY0ziCMIJrmYoDIn9TUAH5lRmiIeZmRd4c6QEZkzdoH7jNnoNyoY1AIESiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.4",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3135,6 +3189,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3284,6 +3347,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -5339,6 +5412,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.4.0.tgz",
+      "integrity": "sha512-6nPDnj8vektWCIOy9ArS3avus9Ndsyz5XgFCJ7nBxXASSpBdSL6lG9jzNNmViPOAOPh6T5oJyGaXuMirBLECag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.3",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -6030,6 +6118,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/temp-dir": {
       "version": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-datepicker": "^8.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -102,6 +102,9 @@ body {
   align-items: center;
   gap: 0.5rem;
 }
+.date-input {
+  width: 8rem;
+}
 .daily-line {
   margin-bottom: 1rem;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -16,15 +16,30 @@ body {
   width: 100%;
   margin-bottom: 1rem;
   text-align: left;
+  table-layout: fixed;
 }
 .scoreboard th,
 .scoreboard td {
   border: 1px solid #ccc;
   padding: 0.5rem;
+  word-break: break-all;
 }
 .round-form select {
   margin: 0.5rem;
   padding: 0.6rem;
+  font-size: 1.2rem;
+  flex: 1;
+}
+.round-form-row {
+  display: flex;
+  align-items: center;
+}
+.round-label {
+  width: 3em;
+  text-align: right;
+}
+.round-third {
+  margin: 0.5rem;
   font-size: 1.2rem;
 }
 .round-form button {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -115,3 +115,8 @@ body {
   background-color: #e67e22;
   color: #fff;
 }
+
+.record-day {
+  background-color: #ffe7c4;
+  border-radius: 50%;
+}

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -95,26 +95,6 @@ body {
   padding: 0.5rem 0;
 }
 
-.date-highlights {
-  margin-top: 0.25rem;
-}
-
-.date-highlights span {
-  margin-right: 0.5rem;
-  cursor: pointer;
-  padding: 0 0.25rem;
-  border-radius: 4px;
-}
-
-.available-date {
-  background-color: #eee;
-  color: #333;
-}
-
-.selected-date {
-  background-color: #e67e22;
-  color: #fff;
-}
 
 .record-day {
   background-color: #ffe7c4;

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -157,27 +157,19 @@ export default function CenterHistory({ onBack }) {
         </div>
       </div>
       <div className='date-filter'>
-        <DatePicker
-          selected={filterDate ? new Date(filterDate) : null}
-          onChange={(d) => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
-          dateFormat='yyyy-MM-dd'
-          dayClassName={(date) =>
-            datesWithRecords.includes(date.toISOString().slice(0, 10))
-              ? 'record-day'
-              : undefined
-          }
-        />
-        <div className='date-highlights'>
-          {datesWithRecords.map((d) => (
-            <span
-              key={d}
-              onClick={() => setFilterDate(d)}
-              className={d === filterDate ? 'selected-date' : 'available-date'}
-            >
-              {d}
-            </span>
-          ))}
-        </div>
+        <label>
+          日期筛选:
+          <DatePicker
+            selected={filterDate ? new Date(filterDate) : null}
+            onChange={(d) => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
+            dateFormat='yyyy-MM-dd'
+            dayClassName={(date) =>
+              datesWithRecords.includes(date.toISOString().slice(0, 10))
+                ? 'record-day'
+                : undefined
+            }
+          />
+        </label>
         <button
           onClick={deleteDate}
           disabled={!filterDate}

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -3,6 +3,12 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import SERVER_URL from '../serverConfig.js';
 
+function formatMoney(v) {
+  if (v > 0) return `+¥${v}`;
+  if (v < 0) return `-¥${Math.abs(v)}`;
+  return `¥${v}`;
+}
+
 function GameItem({ game }) {
   const [open, setOpen] = useState(false);
   const winner = [...game.players].sort(
@@ -18,14 +24,13 @@ function GameItem({ game }) {
         <div className='game-detail'>
           {game.players.map((p) => (
             <div key={p.name}>
-              {p.name}: {p.score}分 净{p.net > 0 ? '+' : ''}
-              {p.net}
+              {p.name}: {p.score}分 净{formatMoney(p.net)}
             </div>
           ))}
           <div>
             支付结果:
             {Object.entries(game.totalPay)
-              .map(([n, v]) => `${n}:${v > 0 ? '+' : ''}${v}`)
+              .map(([n, v]) => `${n}:${formatMoney(v)}`)
               .join(' , ')}
           </div>
           <details>
@@ -134,8 +139,7 @@ export default function CenterHistory({ onBack }) {
           生涯盈亏:
           {Object.entries(totalCareer).map(([n, v]) => (
             <span key={n} style={{ marginRight: '1em' }}>
-              {n}:{v > 0 ? '+' : ''}
-              {v}
+              {n}:{formatMoney(v)}
             </span>
           ))}
         </div>
@@ -182,8 +186,7 @@ export default function CenterHistory({ onBack }) {
         单日盈亏:
         {Object.entries(daily).map(([n, v]) => (
           <span key={n} style={{ marginRight: '1em' }}>
-            {n}:{v > 0 ? '+' : ''}
-            {v}
+            {n}:{formatMoney(v)}
           </span>
         ))}
       </div>

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 import SERVER_URL from '../serverConfig.js';
 
 function GameItem({ game }) {
@@ -157,10 +159,15 @@ export default function CenterHistory({ onBack }) {
       <div className='date-filter'>
         <label>
           日期筛选:
-          <input
-            type='date'
-            value={filterDate}
-            onChange={(e) => setFilterDate(e.target.value)}
+          <DatePicker
+            selected={filterDate ? new Date(filterDate) : null}
+            onChange={(d) => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
+            dateFormat='yyyy-MM-dd'
+            dayClassName={(date) =>
+              datesWithRecords.includes(date.toISOString().slice(0, 10))
+                ? 'record-day'
+                : undefined
+            }
           />
         </label>
         <div className='date-highlights'>

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -172,6 +172,7 @@ export default function CenterHistory({ onBack }) {
                 ? 'record-day'
                 : undefined
             }
+            className='date-input'
           />
         </label>
         <button

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -157,19 +157,16 @@ export default function CenterHistory({ onBack }) {
         </div>
       </div>
       <div className='date-filter'>
-        <label>
-          日期筛选:
-          <DatePicker
-            selected={filterDate ? new Date(filterDate) : null}
-            onChange={(d) => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
-            dateFormat='yyyy-MM-dd'
-            dayClassName={(date) =>
-              datesWithRecords.includes(date.toISOString().slice(0, 10))
-                ? 'record-day'
-                : undefined
-            }
-          />
-        </label>
+        <DatePicker
+          selected={filterDate ? new Date(filterDate) : null}
+          onChange={(d) => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
+          dateFormat='yyyy-MM-dd'
+          dayClassName={(date) =>
+            datesWithRecords.includes(date.toISOString().slice(0, 10))
+              ? 'record-day'
+              : undefined
+          }
+        />
         <div className='date-highlights'>
           {datesWithRecords.map((d) => (
             <span

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -3,6 +3,12 @@ import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import SERVER_URL from '../serverConfig.js'
 
+function formatMoney(v) {
+  if (v > 0) return `+¥${v}`
+  if (v < 0) return `-¥${Math.abs(v)}`
+  return `¥${v}`
+}
+
 function GameItem({ game }) {
   const [open, setOpen] = useState(false)
   const winner = [...game.players].sort((a,b)=> b.score - a.score || a.name.localeCompare(b.name))[0]
@@ -14,9 +20,9 @@ function GameItem({ game }) {
       {open && (
         <div className="game-detail">
           {game.players.map(p=>(
-            <div key={p.name}>{p.name}: {p.score}分 净{p.net>0?'+':''}{p.net}</div>
+            <div key={p.name}>{p.name}: {p.score}分 净{formatMoney(p.net)}</div>
           ))}
-          <div>支付结果:{Object.entries(game.totalPay).map(([n,v])=>`${n}:${v>0?'+':''}${v}`).join(' , ')}</div>
+          <div>支付结果:{Object.entries(game.totalPay).map(([n,v])=>`${n}:${formatMoney(v)}`).join(' , ')}</div>
           <details>
             <summary>回合明细</summary>
             <ol>
@@ -87,7 +93,7 @@ export default function History({ onBack }) {
       <div>
         生涯盈亏:
         {Object.entries(totalCareer).map(([n,v])=> (
-          <span key={n} style={{marginRight:'1em'}}>{n}:{v>0?'+':''}{v}</span>
+          <span key={n} style={{marginRight:'1em'}}>{n}:{formatMoney(v)}</span>
         ))}
       </div>
       <div>
@@ -108,7 +114,7 @@ export default function History({ onBack }) {
       <div>
         单日盈亏:
         {Object.entries(daily).map(([n,v])=> (
-          <span key={n} style={{marginRight:'1em'}}>{n}:{v>0?'+':''}{v}</span>
+          <span key={n} style={{marginRight:'1em'}}>{n}:{formatMoney(v)}</span>
         ))}
       </div>
       <div>

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -91,27 +91,19 @@ export default function History({ onBack }) {
         ))}
       </div>
       <div>
-        <DatePicker
-          selected={filterDate ? new Date(filterDate) : null}
-          onChange={d => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
-          dateFormat="yyyy-MM-dd"
-          dayClassName={date =>
-            datesWithRecords.includes(date.toISOString().slice(0, 10))
-              ? 'record-day'
-              : undefined
-          }
-        />
-        <div className="date-highlights">
-          {datesWithRecords.map(d => (
-            <span
-              key={d}
-              onClick={() => setFilterDate(d)}
-              className={d === filterDate ? 'selected-date' : 'available-date'}
-            >
-              {d}
-            </span>
-          ))}
-        </div>
+        <label>
+          日期筛选:
+          <DatePicker
+            selected={filterDate ? new Date(filterDate) : null}
+            onChange={d => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
+            dateFormat="yyyy-MM-dd"
+            dayClassName={date =>
+              datesWithRecords.includes(date.toISOString().slice(0, 10))
+                ? 'record-day'
+                : undefined
+            }
+          />
+        </label>
       </div>
       <div>
         单日盈亏:

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -108,6 +108,7 @@ export default function History({ onBack }) {
                 ? 'record-day'
                 : undefined
             }
+            className="date-input"
           />
         </label>
       </div>

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import DatePicker from 'react-datepicker'
+import 'react-datepicker/dist/react-datepicker.css'
 import SERVER_URL from '../serverConfig.js'
 
 function GameItem({ game }) {
@@ -90,7 +92,16 @@ export default function History({ onBack }) {
       </div>
       <div>
         <label>日期筛选:
-          <input type="date" value={filterDate} onChange={e=>setFilterDate(e.target.value)} />
+          <DatePicker
+            selected={filterDate ? new Date(filterDate) : null}
+            onChange={d => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
+            dateFormat="yyyy-MM-dd"
+            dayClassName={date =>
+              datesWithRecords.includes(date.toISOString().slice(0, 10))
+                ? 'record-day'
+                : undefined
+            }
+          />
         </label>
         <div className="date-highlights">
           {datesWithRecords.map(d => (

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -91,18 +91,16 @@ export default function History({ onBack }) {
         ))}
       </div>
       <div>
-        <label>日期筛选:
-          <DatePicker
-            selected={filterDate ? new Date(filterDate) : null}
-            onChange={d => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
-            dateFormat="yyyy-MM-dd"
-            dayClassName={date =>
-              datesWithRecords.includes(date.toISOString().slice(0, 10))
-                ? 'record-day'
-                : undefined
-            }
-          />
-        </label>
+        <DatePicker
+          selected={filterDate ? new Date(filterDate) : null}
+          onChange={d => setFilterDate(d ? d.toISOString().slice(0, 10) : '')}
+          dateFormat="yyyy-MM-dd"
+          dayClassName={date =>
+            datesWithRecords.includes(date.toISOString().slice(0, 10))
+              ? 'record-day'
+              : undefined
+          }
+        />
         <div className="date-highlights">
           {datesWithRecords.map(d => (
             <span

--- a/app/src/components/RoundForm.jsx
+++ b/app/src/components/RoundForm.jsx
@@ -22,41 +22,40 @@ export default function RoundForm({ players, onRecord, disabled }) {
 
   return (
     <div className='round-form'>
-      <div>
-        <label>
-          头游:
-          <select
-            value={first}
-            onChange={(e) => setFirst(e.target.value)}
-            disabled={disabled}
-          >
-            <option value=''>选择</option>
-            {players.map((p) => (
-              <option key={p.name} value={p.name}>
-                {p.name}
-              </option>
-            ))}
-          </select>
-        </label>
+      <div className='round-form-row'>
+        <label className='round-label'>上游:</label>
+        <select
+          value={first}
+          onChange={(e) => setFirst(e.target.value)}
+          disabled={disabled}
+        >
+          <option value=''>选择</option>
+          {players.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
       </div>
-      <div>
-        <label>
-          二游:
-          <select
-            value={second}
-            onChange={(e) => setSecond(e.target.value)}
-            disabled={disabled}
-          >
-            <option value=''>选择</option>
-            {players.map((p) => (
-              <option key={p.name} value={p.name}>
-                {p.name}
-              </option>
-            ))}
-          </select>
-        </label>
+      <div className='round-form-row'>
+        <label className='round-label'>二游:</label>
+        <select
+          value={second}
+          onChange={(e) => setSecond(e.target.value)}
+          disabled={disabled}
+        >
+          <option value=''>选择</option>
+          {players.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name}
+            </option>
+          ))}
+        </select>
       </div>
-      <div>末游: {third}</div>
+      <div className='round-form-row'>
+        <span className='round-label'>末游:</span>
+        <span className='round-third'>{third}</span>
+      </div>
       <button onClick={handleRecord} disabled={disabled}>
         记录本局
       </button>

--- a/app/src/components/SettlementModal.jsx
+++ b/app/src/components/SettlementModal.jsx
@@ -1,3 +1,9 @@
+function formatMoney(v) {
+  if (v > 0) return `+¥${v}`;
+  if (v < 0) return `-¥${Math.abs(v)}`;
+  return `¥${v}`;
+}
+
 export default function SettlementModal({ players, pay, pairPay, onNewGame, onSync, synced, canSync }) {
   return (
     <dialog open className='settlement-modal'>
@@ -8,7 +14,7 @@ export default function SettlementModal({ players, pay, pairPay, onNewGame, onSy
             ([other, amt]) =>
               amt > 0 && (
                 <div key={`${p.name}-${other}`} className='settlement-pay'>
-                  {p.name} 支付 {amt}元 给 {other}
+                  {p.name} 支付 {formatMoney(amt)} 给 {other}
                 </div>
               )
           )
@@ -17,8 +23,7 @@ export default function SettlementModal({ players, pay, pairPay, onNewGame, onSy
       <div>
         {players.map((p) => (
           <div key={p.name} className='settlement-score'>
-            {p.name}: {p.score}分 净{pay[p.name] > 0 ? '+' : ''}
-            {pay[p.name]}
+            {p.name}: {p.score}分 净{formatMoney(pay[p.name])}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add `react-datepicker` dependency
- integrate DatePicker in History and CenterHistory to allow customizing date cells
- mark days with records via `record-day` class
- style highlighted days in calendar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880b798e4b0833183cb6e49b4b66fa3