### PR TITLE
Fix zoom and keyboard on date picker

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -104,6 +104,7 @@ body {
 }
 .date-input {
   width: 8rem;
+  font-size: 1rem; /* prevent iOS zoom on focus */
 }
 .daily-line {
   margin-bottom: 1rem;

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -173,6 +173,7 @@ export default function CenterHistory({ onBack }) {
                 : undefined
             }
             className='date-input'
+            readOnly
           />
         </label>
         <button

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -109,6 +109,7 @@ export default function History({ onBack }) {
                 : undefined
             }
             className="date-input"
+            readOnly
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary
- prevent iOS zooming by enforcing 1rem font size on date inputs
- mark date picker inputs as `readOnly` so keyboards don't pop up

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880e9591db08331a30774659522a04a