### PR TITLE
Fix DatePicker on iOS

### DIFF
--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -173,7 +173,6 @@ export default function CenterHistory({ onBack }) {
                 : undefined
             }
             className='date-input'
-            readOnly
           />
         </label>
         <button

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -109,7 +109,6 @@ export default function History({ onBack }) {
                 : undefined
             }
             className="date-input"
-            readOnly
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary
- restore clickable date picker by removing `readOnly` attribute

## Testing
- `npm run lint`
- `npm run build`
- `npm install` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6880ebe955748331b96fc4371b814d30