### PR TITLE
Add gameplay timer and daily count

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -121,13 +121,13 @@ body {
 }
 
 .start-btn {
-  background-color: #90ee90; /* light green */
+  background-color: #66bb6a; /* darker green */
   color: #fff;
   border: none;
 }
 
 .start-btn:hover {
-  background-color: #7ecf7e;
+  background-color: #5ca65c;
 }
 
 .stop-btn {
@@ -138,4 +138,10 @@ body {
 
 .stop-btn:hover {
   background-color: #fb8c00;
+}
+
+.welcome-logo {
+  width: 150px;
+  margin: 1rem auto;
+  display: block;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -121,21 +121,21 @@ body {
 }
 
 .start-btn {
-  background-color: #2ecc71;
+  background-color: #90ee90; /* light green */
   color: #fff;
   border: none;
 }
 
 .start-btn:hover {
-  background-color: #27ae60;
+  background-color: #7ecf7e;
 }
 
 .stop-btn {
-  background-color: #e67e22;
+  background-color: #ffa726; /* orangish */
   color: #fff;
   border: none;
 }
 
 .stop-btn:hover {
-  background-color: #d35400;
+  background-color: #fb8c00;
 }

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -119,3 +119,23 @@ body {
   background-color: #ffe7c4;
   border-radius: 50%;
 }
+
+.start-btn {
+  background-color: #2ecc71;
+  color: #fff;
+  border: none;
+}
+
+.start-btn:hover {
+  background-color: #27ae60;
+}
+
+.stop-btn {
+  background-color: #e67e22;
+  color: #fff;
+  border: none;
+}
+
+.stop-btn:hover {
+  background-color: #d35400;
+}

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -189,7 +189,7 @@ function App() {
     return (
       <div className='app'>
         <h1>记分</h1>
-        <button onClick={startGame}>开始游戏</button>
+        <button onClick={startGame} className='start-btn'>开始游戏</button>
         <div className='actions'>
           <button onClick={() => setShowHistory(true)}>本地记录</button>
           <button
@@ -250,7 +250,7 @@ function App() {
         disabled={game.isFinished}
       />
       <div className='actions'>
-        <button onClick={stopGame}>停止计时</button>
+        <button onClick={stopGame} className='stop-btn'>结束游戏</button>
         <button onClick={undoLastRound} disabled={game.rounds.length === 0}>
           撤销上局
         </button>

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -222,7 +222,7 @@ function App() {
     <div className='app'>
       <h1>记分</h1>
       <div className='status'>
-        用时 {Math.floor(elapsed / 3600000)}:
+        用时 {String(Math.floor(elapsed / 3600000)).padStart(2, '0')}:
         {String(Math.floor((elapsed % 3600000) / 60000)).padStart(2, '0')} {' | '}
         第 {game.rounds.length + 1} 局{' '}
         {game.isFinished ? '已结束' : '尚未有人 > 12 分'}{' | '}

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -58,9 +58,20 @@ function App() {
   const [showCenterHistory, setShowCenterHistory] = useState(false);
   const [isSynced, setIsSynced] = useState(false);
   const [serverConnected, setServerConnected] = useState(false);
-  const [started, setStarted] = useState(false);
-  const [startTime, setStartTime] = useState(null);
-  const [elapsed, setElapsed] = useState(0);
+  const [started, setStarted] = useState(
+    () => localStorage.getItem('gameStarted') === 'true'
+  );
+  const [startTime, setStartTime] = useState(() => {
+    const v = localStorage.getItem('gameStartTime');
+    return v ? parseInt(v, 10) : null;
+  });
+  const [elapsed, setElapsed] = useState(() => {
+    const v = localStorage.getItem('gameStartTime');
+    if (localStorage.getItem('gameStarted') === 'true' && v) {
+      return Date.now() - parseInt(v, 10);
+    }
+    return 0;
+  });
 
   const checkServer = () => {
     fetch(`${SERVER_URL}/games`)
@@ -71,6 +82,18 @@ function App() {
   useEffect(() => {
     saveCurrent(game);
   }, [game]);
+
+  useEffect(() => {
+    if (started) {
+      localStorage.setItem('gameStarted', 'true');
+      if (startTime) {
+        localStorage.setItem('gameStartTime', String(startTime));
+      }
+    } else {
+      localStorage.removeItem('gameStarted');
+      localStorage.removeItem('gameStartTime');
+    }
+  }, [started, startTime]);
 
   useEffect(() => {
     if (!started) return;
@@ -189,6 +212,7 @@ function App() {
     return (
       <div className='app'>
         <h1>记分</h1>
+        <img src='/pwa-512.png' alt='logo' className='welcome-logo' />
         <button onClick={startGame} className='start-btn'>开始游戏</button>
         <div className='actions'>
           <button onClick={() => setShowHistory(true)}>本地记录</button>

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -140,6 +140,7 @@ export default function History({ onBack }) {
           </span>
         ))}
       </div>
+      <div>当日对局次数: {filtered.length}</div>
       <div>
         <button onClick={syncFiltered} disabled={!filterDate || syncing}>
           同步所选日期到中心


### PR DESCRIPTION
## Summary
- add Start/Stop controls and timer to main page
- show play count per day in History page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882123148988331ab629efbbeae905d