### PR TITLE
Improve home navigation and add play time tracking

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -141,7 +141,7 @@ body {
 }
 
 .welcome-logo {
-  width: 150px;
+  width: 200px;
   margin: 1rem auto;
   display: block;
 }

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -65,6 +65,10 @@ function App() {
     const v = localStorage.getItem('gameStartTime');
     return v ? parseInt(v, 10) : null;
   });
+  const [gameStart, setGameStart] = useState(() => {
+    const v = localStorage.getItem('currentGameStart');
+    return v ? parseInt(v, 10) : null;
+  });
   const [elapsed, setElapsed] = useState(() => {
     const v = localStorage.getItem('gameStartTime');
     if (localStorage.getItem('gameStarted') === 'true' && v) {
@@ -89,11 +93,15 @@ function App() {
       if (startTime) {
         localStorage.setItem('gameStartTime', String(startTime));
       }
+      if (gameStart) {
+        localStorage.setItem('currentGameStart', String(gameStart));
+      }
     } else {
       localStorage.removeItem('gameStarted');
       localStorage.removeItem('gameStartTime');
+      localStorage.removeItem('currentGameStart');
     }
-  }, [started, startTime]);
+  }, [started, startTime, gameStart]);
 
   useEffect(() => {
     if (!started) return;
@@ -138,6 +146,7 @@ function App() {
     const stored = JSON.parse(localStorage.getItem('games') || '[]');
     stored.unshift({
       timestamp: Date.now(),
+      duration: gameStart ? Date.now() - gameStart : 0,
       players: finishedPlayers,
       rounds: game.rounds,
       totalPay: pay,
@@ -151,6 +160,7 @@ function App() {
     const newGame = { players: freshPlayers, rounds: [], isFinished: false };
     setGame(newGame);
     setIsSynced(false);
+    setGameStart(Date.now());
   };
 
   const syncGame = async () => {
@@ -161,6 +171,7 @@ function App() {
     }));
     const body = {
       timestamp: Date.now(),
+      duration: gameStart ? Date.now() - gameStart : 0,
       players: finishedPlayers,
       rounds: game.rounds,
       totalPay: pay,
@@ -198,6 +209,7 @@ function App() {
 
   const startGame = () => {
     setStartTime(Date.now());
+    setGameStart(Date.now());
     setElapsed(0);
     setStarted(true);
   };
@@ -206,9 +218,16 @@ function App() {
     setStarted(false);
     setElapsed(0);
     setStartTime(null);
+    setGameStart(null);
   };
 
   if (!started) {
+    if (showCenterHistory) {
+      return <CenterHistory onBack={() => setShowCenterHistory(false)} />;
+    }
+    if (showHistory) {
+      return <History onBack={() => setShowHistory(false)} />;
+    }
     return (
       <div className='app'>
         <h1>记分</h1>
@@ -225,10 +244,6 @@ function App() {
             云端记录
           </button>
         </div>
-        {showHistory && <History onBack={() => setShowHistory(false)} />}
-        {showCenterHistory && (
-          <CenterHistory onBack={() => setShowCenterHistory(false)} />
-        )}
       </div>
     );
   }

--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -9,6 +9,12 @@ function formatMoney(v) {
   return `¥${v}`;
 }
 
+function formatDuration(ms) {
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  return `${h}小时${m}分`;
+}
+
 function DateButton({ value, onClick }) {
   return (
     <button type='button' className='date-input' onClick={onClick}>
@@ -25,8 +31,8 @@ function GameItem({ game }) {
   return (
     <li className='game-item'>
       <div onClick={() => setOpen(!open)} style={{ cursor: 'pointer' }}>
-        {new Date(game.timestamp).toLocaleString()} - 胜者:{winner.name} 用时
-        {game.rounds.length}局
+        {new Date(game.timestamp).toLocaleString()} - 胜者:{winner.name} 共
+        {game.rounds.length}局 用时{formatDuration(game.duration || 0)}
       </div>
       {open && (
         <div className='game-detail'>
@@ -109,6 +115,10 @@ export default function CenterHistory({ onBack }) {
     Object.entries(g.totalPay).forEach(([n, v]) => {
       daily[n] = (daily[n] || 0) + v;
     });
+  });
+  let dailyDuration = 0;
+  filtered.forEach((g) => {
+    dailyDuration += g.duration || 0;
   });
 
   // calculate win rates
@@ -201,6 +211,7 @@ export default function CenterHistory({ onBack }) {
           </span>
         ))}
       </div>
+      <div className='daily-line'>当日游戏时长: {formatDuration(dailyDuration)}</div>
       <ul>
         {filtered.map((g) => (
           <GameItem key={g.timestamp} game={g} />

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -9,6 +9,12 @@ function formatMoney(v) {
   return `¥${v}`;
 }
 
+function formatDuration(ms) {
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  return `${h}小时${m}分`;
+}
+
 function DateButton({ value, onClick }) {
   return (
     <button type='button' className='date-input' onClick={onClick}>
@@ -25,8 +31,8 @@ function GameItem({ game }) {
   return (
     <li className='game-item'>
       <div onClick={() => setOpen(!open)} style={{ cursor: 'pointer' }}>
-        {new Date(game.timestamp).toLocaleString()} - 胜者:{winner.name} 用时
-        {game.rounds.length}局
+        {new Date(game.timestamp).toLocaleString()} - 胜者:{winner.name} 共
+        {game.rounds.length}局 用时{formatDuration(game.duration || 0)}
       </div>
       {open && (
         <div className='game-detail'>
@@ -89,6 +95,10 @@ export default function History({ onBack }) {
       daily[n] = (daily[n] || 0) + v;
     });
   });
+  let dailyDuration = 0;
+  filtered.forEach((g) => {
+    dailyDuration += g.duration || 0;
+  });
 
   const syncFiltered = async () => {
     if (!filterDate) return;
@@ -141,6 +151,7 @@ export default function History({ onBack }) {
         ))}
       </div>
       <div>当日对局次数: {filtered.length}</div>
+      <div>当日游戏时长: {formatDuration(dailyDuration)}</div>
       <div>
         <button onClick={syncFiltered} disabled={!filterDate || syncing}>
           同步所选日期到中心


### PR DESCRIPTION
## Summary
- enlarge welcome icon
- navigate to history screens on home page
- track game duration and persist it
- show daily play time in local/cloud history

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68852c0725f48331926c579b0787409f