### PR TITLE
Remove per-game play time display

### DIFF
--- a/app/src/components/CenterHistory.jsx
+++ b/app/src/components/CenterHistory.jsx
@@ -32,7 +32,7 @@ function GameItem({ game }) {
     <li className='game-item'>
       <div onClick={() => setOpen(!open)} style={{ cursor: 'pointer' }}>
         {new Date(game.timestamp).toLocaleString()} - 胜者:{winner.name} 共
-        {game.rounds.length}局 用时{formatDuration(game.duration || 0)}
+        {game.rounds.length}局
       </div>
       {open && (
         <div className='game-detail'>

--- a/app/src/components/History.jsx
+++ b/app/src/components/History.jsx
@@ -32,7 +32,7 @@ function GameItem({ game }) {
     <li className='game-item'>
       <div onClick={() => setOpen(!open)} style={{ cursor: 'pointer' }}>
         {new Date(game.timestamp).toLocaleString()} - 胜者:{winner.name} 共
-        {game.rounds.length}局 用时{formatDuration(game.duration || 0)}
+        {game.rounds.length}局
       </div>
       {open && (
         <div className='game-detail'>


### PR DESCRIPTION
## Summary
- hide duration for each game entry in history lists
- keep showing total play time per day

## Testing
- `npm install` in /app
- `npm run lint`
- `npm install` in /server
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_68852f0ab42883319fc1b752725dd0ef