### PR TITLE
Add session payment summary

### DIFF
--- a/app/src/components/TotalSettlementModal.jsx
+++ b/app/src/components/TotalSettlementModal.jsx
@@ -1,0 +1,35 @@
+function formatMoney(v) {
+  if (v > 0) return `+¥${v}`;
+  if (v < 0) return `-¥${Math.abs(v)}`;
+  return `¥${v}`;
+}
+
+export default function TotalSettlementModal({ players, pay, pairPay, onConfirm }) {
+  return (
+    <dialog open className='settlement-modal'>
+      <h2>总结算</h2>
+      <div>
+        {players.flatMap((p) =>
+          Object.entries(pairPay[p.name]).map(
+            ([other, amt]) =>
+              amt > 0 && (
+                <div key={`${p.name}-${other}`} className='settlement-pay'>
+                  {p.name} 支付 {formatMoney(amt)} 给 {other}
+                </div>
+              )
+          )
+        )}
+      </div>
+      <div>
+        {players.map((p) => (
+          <div key={p.name} className='settlement-score'>
+            {p.name}: 净{formatMoney(pay[p.name])}
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: '1em' }}>
+        <button onClick={onConfirm} className='new-game-btn'>确定</button>
+      </div>
+    </dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- calculate overall pair pay for the whole session
- show a popup with total payments when ending a session

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688688318f9c8331941974f259372289